### PR TITLE
package guesstimating wit renv::dependencies (#53, #55)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,8 @@ Imports:
     remotes,
     utils,
     httr,
-    vctrs
+    vctrs,
+    renv
 Depends: 
     R (>= 3.5.0)
 VignetteBuilder: knitr

--- a/tests/testdata/test_dir/script.R
+++ b/tests/testdata/test_dir/script.R
@@ -1,0 +1,2 @@
+library(BiocGenerics)
+library(rtoot)

--- a/tests/testthat/test_pkgref.R
+++ b/tests/testthat/test_pkgref.R
@@ -107,3 +107,15 @@ test_that(".detect_renv_lockfile false",{
     expect_false(.detect_renv_lockfile(c("../testdata/graph.RDS", "../testdata/renv.lock")))
     expect_false(.detect_renv_lockfile("../testdata/fake_renv.lock"))
 })
+
+test_that(".is_directory flse",{
+    expect_false(.is_directory(c("a/","b/")))
+    expect_false(.is_directory("a/"))
+})
+
+test_that("as_pkgrefs directory", {
+    skip_if_offline()
+    skip_on_cran()
+    res <- suppressWarnings(as_pkgrefs("../testdata/test_dir",bioc_version = "3.16"))
+    expect_equal(res, c("bioc::BiocGenerics", "cran::rtoot"))
+})


### PR DESCRIPTION
if input is detected to be  valid directory, `renv::dependencies` is used. A warning is displayed that github packages cannot be resolved